### PR TITLE
fix logical error in updating the most seen sequence for UMI

### DIFF
--- a/AmpUMI/AmpUMI.py
+++ b/AmpUMI/AmpUMI.py
@@ -94,7 +94,7 @@ def dedupUMIs(args,parser):
                 else:
                     umi_key_counts[this_UMI] += 1
                     #if this sequence is the most seen for this UMI, store it
-                    if umi_seq_counts[this_key] > umi_key_counts[this_UMI]:
+                    if umi_seq_counts[this_key] > umi_seq_counts[umi_keys_with_most_counts[this_UMI]]:
                         umi_keys_with_most_counts[this_UMI] = this_key
 
     if read_count == 0:


### PR DESCRIPTION
Firstly, thank you very much for creating this wonderful tool for UMI based amplicon deduplication.
However, after I read your paper, documents, and the source code of this repo, I might found some bug here.
I think the logic of update the most seen sequence for one UMI is like below,
If the the current sequence count for this UMI is larger than the old most seen sequence count for this UMI
then we should update the most seen sequence for this UMI with the current sequence.
However the original code in this repo is comparing the current sequence count of the current UMI with total reads this UMI have seen before. Is this a bug or I didn't got it right somewhere?
